### PR TITLE
Add the offscreen rendering functionality

### DIFF
--- a/code/cerebro/cerebro_brain_viewer.py
+++ b/code/cerebro/cerebro_brain_viewer.py
@@ -593,6 +593,9 @@ class Cerebro_brain_viewer():
     def draw_to_matplotlib_axes(self, ax):
         """Draw an offscreen-rendered view to a matplotlib axes.
 
+        Note: this functionality is experimental and might not fully work depending on
+        viewer configuration.
+
         Args:
             ax (matplotlib.Axes): the axes into which the view will be drawn.
         """

--- a/code/cerebro/cerebro_window.py
+++ b/code/cerebro/cerebro_window.py
@@ -36,8 +36,9 @@ load_prc_file_data('', 'win-size 1280 720')
 
 class Cerebro_window(ShowBase):
 
-    def __init__(self, background_color=(0.1, 0.1, 0.1, 0.0), camera_pos=(400, 0, 0), camera_target=(0, 0, 0), camera_fov=35, camera_rotation=0, rotation_speed=100, movement_speed=100, zoom_speed=0.2, window_size=(1280, 720)):
-        super().__init__(self)
+    def __init__(self, background_color=(0.1, 0.1, 0.1, 0.0), camera_pos=(400, 0, 0), camera_target=(0, 0, 0), camera_fov=35, camera_rotation=0, rotation_speed=100, movement_speed=100, zoom_speed=0.2, window_size=(1280, 720), offscreen=False):
+        windowType = 'offscreen' if offscreen else None
+        super().__init__(self, windowType=windowType)
 
         # Initial configurations
         self.set_background_color(*list(background_color))
@@ -49,10 +50,13 @@ class Cerebro_window(ShowBase):
         window_properties.set_size(window_size[0], window_size[1])
         window_properties.set_title('Cerebro Viewer')
         window_properties.set_icon_filename('Cerebro_Viewer.ico')
-        self.win.requestProperties(window_properties)
+        self._window_properties = window_properties
 
-        # Keyboard and mouse setup
-        self.setup_keyboard_and_mouse()
+        if not offscreen:
+            self.win.requestProperties(window_properties)
+
+            # Keyboard and mouse setup
+            self.setup_keyboard_and_mouse()
 
         # Camera positioning
         # position is relative to target
@@ -67,11 +71,12 @@ class Cerebro_window(ShowBase):
         self.movement_speed = movement_speed
         self.zoom_speed = zoom_speed
 
-        # Add the update task to the task manager.
-        self.taskMgr.add(self.update_task, "update_task")
+        if not offscreen:
+            # Add the update task to the task manager.
+            self.taskMgr.add(self.update_task, "update_task")
 
-        # Add the repeated checking task to the task manager
-        self.taskMgr.doMethodLater(0.05, self.repeated_checks_task, "repeated_checks_task")
+            # Add the repeated checking task to the task manager
+            self.taskMgr.doMethodLater(0.05, self.repeated_checks_task, "repeated_checks_task")
 
         # Create a dictionary for rendered objects
         self.created_objects = {}


### PR DESCRIPTION
Ref #14 

This makes it possible to render the view offscreen and plot it into a matplotlib axes object.

The implementation is experimental not well tested, but it works under simple use cases.

Example usage:
```python
######################
# setup the viewer using `offscreen=True`

from cerebro import cerebro_brain_utils as cbu
from cerebro import cerebro_brain_viewer as cbv

my_brain_viewer = cbv.Cerebro_brain_viewer(offscreen=True)

# render a surface
surface = 'pial'
surface_model = my_brain_viewer.load_template_GIFTI_cortical_surface_models(surface)

cifti_space = my_brain_viewer.visualize_cifti_space()

# render data over surface
dscalar_file = cbu.get_data_file(f'templates/HCP/dscalars/hcp.gradients.dscalar.nii')
dscalar_layer = my_brain_viewer.add_cifti_dscalar_layer(dscalar_file=dscalar_file,)

###################
# draw the view to matplotlib

import matplotlib.pyplot as plt

plt.figure(figsize=(12, 5))
ax = plt.subplot(1, 2, 1)
my_brain_viewer.change_view('R')
my_brain_viewer.draw_to_matplotlib_axes(ax)

ax = plt.subplot(1, 2, 2)
my_brain_viewer.change_view('L')
my_brain_viewer.draw_to_matplotlib_axes(ax)

```

**Known issues:**
* a warning is displayed when setting up the offscreen viewer:
```
:display(warning): FrameBufferProperties available less than requested.
  requested: depth_bits=1 color_bits=3 red_bits=1 green_bits=1 blue_bits=1 alpha_bits=1 back_buffers=1 force_hardware 
  got: depth_bits=24 color_bits=24 red_bits=8 green_bits=8 blue_bits=8 alpha_bits=8 stencil_bits=8 force_hardware 
```
